### PR TITLE
Changed address of ETC deployment

### DIFF
--- a/utils/addresses.ts
+++ b/utils/addresses.ts
@@ -1,6 +1,6 @@
 export const OracleFactories = {
   534351: '0xF72f1B809C734b1C47930D01636936EA28d7484B',
-  61: '0xA898101a4E6Db0FBc2CdA178e1EE82DCB84CdF91',
+  61: '0x4f007748666F2b941AA014E5a2a41841e681A32b',
 } as {
   [key: number]: `0x${string}`
 }


### PR DESCRIPTION
Changes OracleFactory address of deployment on ETC network. 

Why was the old address removed?
- It assumed ETC supports MCOPY like ETH and Scroll sepolia but ETC, yet does not support MCOPY